### PR TITLE
Removing lombok from entity service

### DIFF
--- a/src/main/java/com/api/demo/services/EntityServiceImpl.java
+++ b/src/main/java/com/api/demo/services/EntityServiceImpl.java
@@ -3,20 +3,19 @@ package com.api.demo.services;
 import com.api.demo.models.ModelEntity;
 import com.api.demo.models.ModelEntityDTO;
 import com.api.demo.repositories.EntityPersistence;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import com.api.demo.repositories.ModelEntityRepository;
 
 import java.util.List;
 import java.util.Optional;
 
 @Service
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class EntityServiceImpl implements EntityService {
 
     private final EntityPersistence repository;
+
+    public EntityServiceImpl(EntityPersistence repository) {
+        this.repository = repository;
+    }
 
     @Override
     public List<ModelEntity> findAll() {


### PR DESCRIPTION
Not all IDE support the annotation processing for Lombok to compile. Mine couldn't resolve this annotation:

> @RequiredArgsConstructor(onConstructor = @__(@Autowired))

So it is better to replace it for the constructor.