### PR TITLE
Adding jacoco html report gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,14 @@ repositories {
 	mavenCentral()
 }
 
+jacocoTestReport {
+	reports {
+		xml.enabled false
+		csv.enabled false
+		html.destination file("${buildDir}/jacocoHtml")
+	}
+}
+
 dependencies {
 	compile('io.springfox:springfox-swagger2:2.9.2')
 	compile('io.springfox:springfox-swagger-ui:2.9.2')


### PR DESCRIPTION
This task will generate the html report on "jacocoHtml" folder inside the gradle build folder.